### PR TITLE
fix: check if player is in adventure mode when picking villager

### DIFF
--- a/src/main/java/org/samo_lego/simplevillagers/util/VillagerUtil.java
+++ b/src/main/java/org/samo_lego/simplevillagers/util/VillagerUtil.java
@@ -32,7 +32,7 @@ public interface VillagerUtil {
     }
 
     static InteractionResult onUseEntity(Player player, Level level, InteractionHand hand, Entity entity, @Nullable EntityHitResult hitResult) {
-        if (player instanceof ServerPlayer pl && entity instanceof Villager villager && pl.isShiftKeyDown() && Permissions.check(pl, "simplevillagers.villager_item.pickup", true)) {
+        if (player instanceof ServerPlayer pl && entity instanceof Villager villager && pl.isShiftKeyDown() && (Permissions.check(pl, "simplevillagers.villager_item.pickup", true) && player.mayBuild())) {
             if (villager.isLeashed()) {
                 villager.dropLeash(true, true);
             }


### PR DESCRIPTION
@samolego this is needed for BlanketCon, we don't have luckperms.

If you don't want to merge this, tell me and I can give the organisers a build from my fork to use on the BC server.