### PR TITLE
Fix IronFarmBlockEntity#produceIron method

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
-minecraft_version=1.20
+minecraft_version=1.20.4
 yarn_mappings=1.20+build.1
-loader_version=0.14.21
+loader_version=0.15.7
 #Fabric api
-fabric_version=0.83.0+1.20
+fabric_version=0.96.11+1.20.4
 # Mod Properties
-mod_version=1.4.6
+mod_version=1.4.7
 maven_group=org.samo_lego
 archives_base_name=simplevillagers
 # Dependencies
-sgui_version=1.2.2+1.20
-stapi_version=2.0.0-beta.2+1.19.4-pre2
-polymer_version=0.5.0-rc.3+1.20
+sgui_version=1.4.2+1.20.4
+stapi_version=2.2.0+1.20.3-rc1
+polymer_version=0.7.6+1.20.4
 config2brigadier_version=1.2.5

--- a/src/main/java/org/samo_lego/simplevillagers/block/entity/IronFarmBlockEntity.java
+++ b/src/main/java/org/samo_lego/simplevillagers/block/entity/IronFarmBlockEntity.java
@@ -79,8 +79,9 @@ public class IronFarmBlockEntity extends AbstractFarmBlockEntity {
         ResourceLocation resourceLocation = EntityType.IRON_GOLEM.getDefaultLootTable();
         LootTable lootTable = ((ServerLevel) this.level).getServer().getLootData().getLootTable(resourceLocation);
         LootContext.Builder builder = this.createLootContext();
+        LootContext lootContext = builder.create(Optional.of(new ResourceLocation(MOD_ID)));
 
-        lootTable.getRandomItems(builder.create(new ResourceLocation(MOD_ID)), this::fillIron);
+        lootTable.getRandomItems(lootContext, this::fillIron);
     }
 
     private void fillIron(ItemStack stack) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,9 +31,9 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.12.12",
+    "fabricloader": ">=0.15.7",
     "fabric": "*",
-    "minecraft": ">=1.19",
+    "minecraft": ">=1.20.4",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
It was crashing because minecraft LootContext.Builder#create changed interface and expects Optional instead of Nullable

Bump minecraft version to 1.20.4

Bump fabric version to latest

Bump dependencies versions to latest